### PR TITLE
removing indentation in multiline f-strings

### DIFF
--- a/main.py
+++ b/main.py
@@ -1167,9 +1167,9 @@ class StatsCmdGroup(app_commands.Group):
 
         server_stats_embed = discord.Embed(
             description=f'''Current Chain Length: {config.current_count}
-        Longest chain length: {config.high_score}
-        {f"**Last word:** {config.current_word}" if config.current_word else ""}
-        {f"Last word by: <@{config.current_member_id}>" if config.current_member_id else ""}''',
+Longest chain length: {config.high_score}
+{f"**Last word:** {config.current_word}" if config.current_word else ""}
+{f"Last word by: <@{config.current_member_id}>" if config.current_member_id else ""}''',
             color=discord.Color.blurple()
         )
         server_stats_embed.set_author(name=interaction.guild, icon_url=interaction.guild.icon)
@@ -1210,10 +1210,10 @@ class StatsCmdGroup(app_commands.Group):
         emb = discord.Embed(
             color=discord.Color.blue(),
             description=f'''**Score:** {score} (#{pos_by_score})
-        **🌟Karma:** {karma:.2f} (#{pos_by_karma})
-        **✅Correct:** {correct}
-        **❌Wrong:** {wrong}
-        **Accuracy:** {(correct / (correct + wrong)):.2%}'''
+**🌟Karma:** {karma:.2f} (#{pos_by_karma})
+**✅Correct:** {correct}
+**❌Wrong:** {wrong}
+**Accuracy:** {(correct / (correct + wrong)):.2%}'''
         ).set_author(name=f"{member} | stats", icon_url=member.avatar)
 
         await interaction.followup.send(embed=emb)


### PR DESCRIPTION
The multiline f-strings preserve the whitespaces in the lines after the first one. This causes the following issues on mobile devices:  

<a href="https://github.com/WrichikBasu/word_chain_bot_indently/assets/62506842/617030e1-7386-4991-9843-f56dbac59f50"><img src="https://github.com/WrichikBasu/word_chain_bot_indently/assets/62506842/617030e1-7386-4991-9843-f56dbac59f50" width="500" alt="Embeds with whitespace"/></a>

On desktop devices, the client renders the embed differently, so it wasn't visible there. With the fix, it looks now like that:   

<a href="https://github.com/WrichikBasu/word_chain_bot_indently/assets/62506842/e2960bab-5260-41b5-a645-7a7bcef9b3c1"><img src="https://github.com/WrichikBasu/word_chain_bot_indently/assets/62506842/e2960bab-5260-41b5-a645-7a7bcef9b3c1" width="500" alt="Embeds with whitespace"/></a>

The same also applied to the users stats. If the removed indentation looks weird in the code, we can also use separate f-strings in each line, either with explicit or implicit concatenation. But we would have to add explicit line breaks then.
