### PR TITLE
weighted history for karma balancing

### DIFF
--- a/data.py
+++ b/data.py
@@ -97,5 +97,4 @@ def calculate_total_karma(word: str, last_words: LimitedLengthList) -> float:
 
     decay: float = calculate_decay(n)
     base_karma: float = calculate_base_karma(word)
-    karma = decay * base_karma if base_karma > 0 else base_karma
-    return karma
+    return decay * base_karma if base_karma > 0 else base_karma

--- a/data.py
+++ b/data.py
@@ -1,4 +1,6 @@
+import math
 from collections import deque
+from consts import FIRST_CHAR_SCORE
 
 
 class LimitedLengthList(deque):
@@ -13,10 +15,87 @@ class LimitedLengthList(deque):
 
 
 class History(dict[int, LimitedLengthList[str]]):
-    def __init__(self, history_length: int = 10, *args, **kwargs):
+    def __init__(self, history_length: int = 5, *args, **kwargs):
         self.__history_length = history_length
         super().__init__(*args, **kwargs)
 
     def __missing__(self, key):
         self[key] = LimitedLengthList(self.__history_length)
         return self[key]
+
+
+def calculate_decay(n: float, drop_rate: float = .33) -> float:
+    """
+    Calculates a decay factor based on an occurrence score of same letter ending words in history.
+
+    Parameters
+    ----------
+    n : float
+        Positive score of occurrences in history.
+    drop_rate : float
+        Positive rate of change to approach the lower boundary.
+
+    Returns
+    -------
+    float
+        A decay factor between 1 and -1 that can be multiplied with the karma.
+    """
+    return (2 * math.e ** (-n * drop_rate)) - 1
+
+
+def calculate_base_karma(word: str, last_char_bias: float = .7) -> float:
+    """
+    Calculates the base karma gain or loss for given word.
+
+    Parameters
+    ----------
+    word : str
+        The word to calculate the karma change from.
+    last_char_bias : float
+        Bias to be multiplied with the karma part for the last character.
+
+    Returns
+    -------
+    float
+        The change in karma, usually closely around 0.
+    """
+
+    def score_adaption(score: float, exponent: float = .5, rise: float = .025) -> float:
+        return score ** exponent + rise
+
+    first_char_score: float = score_adaption(FIRST_CHAR_SCORE[word[0]])  # how difficult is it to find this word
+    last_char_score: float = score_adaption(FIRST_CHAR_SCORE[word[-1]])  # how difficult is it for the next player
+
+    first_char_karma: float = (first_char_score - 1) * -1  # distance to average, inverted
+    last_char_karma: float = (last_char_score - 1)  # distance to average
+
+    # no karma loss if first char is common, because you cannot choose the first one, it is determined by last one
+    # apply bias to last characters karma to fine tune the total influence
+    return (first_char_karma if first_char_karma > 0 else 0) + (last_char_karma * last_char_bias)
+
+
+def calculate_total_karma(word: str, last_words: LimitedLengthList) -> float:
+    """
+    Calculates the total karma gain or loss for given word and history.
+
+    Parameters
+    ----------
+    word : str
+        The word to calculate the karma change from.
+    last_words : LimitedLengthList
+        The history to include in the karma calculation.
+
+    Returns
+    -------
+    float
+        The total change in karma, usually closely around 0.
+    """
+    end_letter: str = word[-1]
+    weighted_words: list[tuple[float, str]] = [(2 * (len(last_words) - index) / len(last_words), e) for index, e in
+                                               enumerate(last_words)]
+    n: float = sum(weight for weight, e in weighted_words if e[-1] == end_letter)
+
+    decay: float = calculate_decay(n)
+    base_karma: float = calculate_base_karma(word)
+    karma = decay * base_karma if base_karma > 0 else base_karma
+    return karma

--- a/data.py
+++ b/data.py
@@ -13,7 +13,7 @@ class LimitedLengthList(deque):
 
 
 class History(dict[int, LimitedLengthList[str]]):
-    def __init__(self, history_length: int = 5, *args, **kwargs):
+    def __init__(self, history_length: int = 10, *args, **kwargs):
         self.__history_length = history_length
         super().__init__(*args, **kwargs)
 

--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@
 import asyncio
 import concurrent.futures
 import json
-import math
 import os
 import sqlite3
 from dataclasses import dataclass
@@ -13,7 +12,7 @@ from discord import app_commands
 from discord.ext import commands
 from dotenv import load_dotenv
 from consts import *
-from data import History, LimitedLengthList
+from data import History, LimitedLengthList, calculate_total_karma
 
 load_dotenv('.env')
 
@@ -456,17 +455,8 @@ The above entered word is **NOT** being taken into account.''')
         else:
             await message.add_reaction(self._config.reaction_emoji())
 
-        # find occurrences and push used word
-        end_letter: str = word[-1]
         last_words: LimitedLengthList[str] = self._history[message.author.id]
-        weighted_words: list[tuple[float, str]] = [((len(last_words) - index) / len(last_words), e) for index, e in
-                                                   enumerate(last_words)]
-        n: float = sum(weight for weight, e in weighted_words if e[-1] == end_letter)
-
-        decay: float = self.calculate_decay(n)
-        base_karma: float = self.calculate_karma(word)
-        karma = decay * base_karma if base_karma > 0 else base_karma
-
+        karma: float = calculate_total_karma(word, last_words)
         self._history[message.author.id].append(word)
 
         cursor.execute(f'UPDATE {Bot.TABLE_MEMBERS} '
@@ -769,56 +759,6 @@ The above entered word is **NOT** being taken into account.''')
                        f'server_id = {server_id} AND words = \'{word}\')')
         result: int = (cursor.fetchone())[0]
         return result == 1
-
-    @staticmethod
-    def calculate_decay(n: float, drop_rate: float = .33) -> float:
-        """
-        Calculates a decay factor based on an occurrence score of same letter ending words in history.
-
-        Parameters
-        ----------
-        n : float
-            Positive score of occurrences in history.
-        drop_rate : float
-            Positive rate of change to approach the lower boundary.
-
-        Returns
-        -------
-        float
-            A decay factor between 1 and -1 that can be multiplied with the karma.
-        """
-        return (2 * math.e ** (-n * drop_rate)) - 1
-
-    @staticmethod
-    def calculate_karma(word: str, last_char_bias: float = .7) -> float:
-        """
-        Calculates the karma gain or loss for given word.
-
-        Parameters
-        ----------
-        word : str
-            The word to calculate the karma change from.
-        last_char_bias : float
-            Bias to be multiplied with the karma part for the last character.
-
-        Returns
-        -------
-        float
-            The change in karma, usually closely around 0.
-        """
-
-        def score_adaption(score: float, exponent: float = .5, rise: float = .025) -> float:
-            return score ** exponent + rise
-
-        first_char_score: float = score_adaption(FIRST_CHAR_SCORE[word[0]])  # how difficult is it to find this word
-        last_char_score: float = score_adaption(FIRST_CHAR_SCORE[word[-1]])  # how difficult is it for the next player
-
-        first_char_karma: float = (first_char_score - 1) * -1  # distance to average, inverted
-        last_char_karma: float = (last_char_score - 1)  # distance to average
-
-        # no karma loss if first char is common, because you cannot choose the first one, it is determined by last one
-        # apply bias to last characters karma to fine tune the total influence
-        return (first_char_karma if first_char_karma > 0 else 0) + (last_char_karma * last_char_bias)
 
     async def setup_hook(self) -> NoReturn:
         await self.tree.sync()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8.2.1
+-r requirements.txt

--- a/test.py
+++ b/test.py
@@ -70,12 +70,17 @@ def test_positive_score_on_unused(positive_scoring_words: list[str], mixed_score
         assert karma > 0
 
 
-def test_positive_score_on_already_used(positive_scoring_words: list[str], positive_score_history: LimitedLengthList):
+def test_reduced_score_on_already_used(positive_scoring_words: list[str],
+                                       positive_score_history: LimitedLengthList,
+                                       negative_score_history: LimitedLengthList):
     for word in positive_scoring_words:
         assert word in positive_score_history
-        karma = calculate_total_karma(word, positive_score_history)
+        karma_on_positive_history = calculate_total_karma(word, positive_score_history)
+        karma_on_negative_history = calculate_total_karma(word, negative_score_history)
         positive_score_history.append(word)
-        assert karma > 0
+        negative_score_history.append(word)
+        assert karma_on_positive_history > 0
+        assert karma_on_positive_history < karma_on_negative_history
 
 
 def test_negative_score_irrelevant_history(negative_scoring_words: list[str],

--- a/test.py
+++ b/test.py
@@ -1,0 +1,101 @@
+import pytest
+import math
+from data import LimitedLengthList, calculate_total_karma
+
+LIST_LENGTH = 5
+
+
+@pytest.fixture
+def empty_history():
+    return LimitedLengthList(LIST_LENGTH)
+
+
+@pytest.fixture
+def positive_scoring_words():
+    return ['as', 'arctic', 'app', 'alu', 'arena']
+
+
+@pytest.fixture
+def negative_scoring_words():
+    return ['any', 'allow', 'mix', 'blitz', 'bank']
+
+
+@pytest.fixture
+def mixed_scoring_words():
+    return ['age', 'armament', 'wish', 'finder', 'colab']
+
+
+@pytest.fixture
+def same_ending_letter_words():
+    return ['as', 'souls', 'picks', 'clicks', 'mountains']
+
+
+@pytest.fixture
+def positive_score_history(positive_scoring_words: list[str]):
+    last_words = LimitedLengthList(LIST_LENGTH)
+    for word in positive_scoring_words:
+        last_words.append(word)
+    return last_words
+
+
+@pytest.fixture
+def negative_score_history(negative_scoring_words: list[str]):
+    last_words = LimitedLengthList(LIST_LENGTH)
+    for word in negative_scoring_words:
+        last_words.append(word)
+    return last_words
+
+
+@pytest.fixture
+def mixed_score_history(mixed_scoring_words: list[str]):
+    last_words = LimitedLengthList(LIST_LENGTH)
+    for word in mixed_scoring_words:
+        last_words.append(word)
+    return last_words
+
+
+@pytest.fixture
+def same_ending_letter_history(same_ending_letter_words: list[str]):
+    last_words = LimitedLengthList(LIST_LENGTH)
+    for word in same_ending_letter_words:
+        last_words.append(word)
+    return last_words
+
+
+def test_positive_score_on_unused(positive_scoring_words: list[str], mixed_score_history: LimitedLengthList):
+    for word in positive_scoring_words:
+        assert word not in mixed_score_history
+        karma = calculate_total_karma(word, mixed_score_history)
+        mixed_score_history.append(word)
+        assert karma > 0
+
+
+def test_positive_score_on_already_used(positive_scoring_words: list[str], positive_score_history: LimitedLengthList):
+    for word in positive_scoring_words:
+        assert word in positive_score_history
+        karma = calculate_total_karma(word, positive_score_history)
+        positive_score_history.append(word)
+        assert karma > 0
+
+
+def test_negative_score_irrelevant_history(negative_scoring_words: list[str],
+                                           negative_score_history: LimitedLengthList,
+                                           positive_score_history: LimitedLengthList):
+    for word in negative_scoring_words:
+        assert word in negative_score_history
+        assert word not in positive_score_history
+        karma_on_negative_history = calculate_total_karma(word, negative_score_history)
+        karma_on_positive_history = calculate_total_karma(word, positive_score_history)
+        negative_score_history.append(word)
+        positive_score_history.append(word)
+        assert karma_on_negative_history == karma_on_positive_history
+
+
+def test_decrease_on_same_ending_letter(same_ending_letter_words: list[str], empty_history: LimitedLengthList):
+    # NOTE: value decreases as long as the list length limit is not reached
+    last_karma = math.inf
+    for word in same_ending_letter_words:
+        karma = calculate_total_karma(word, empty_history)
+        assert karma < last_karma
+        last_karma = karma
+        empty_history.append(word)


### PR DESCRIPTION
Two ideas have been implemented so far:
* applying an adaption function for the first character scores, that reduces "high risers" like the `s` and also adds a small constant amount to make the slightly below average characters less negative
* weighting the history and use this as a score instead for the decay function

I also increased the history length to equalize the new history score, because it is now much lower when using just the same ending letter.