### PR TITLE
Fix `NoneType` error in leaderboard guild icon_url

### DIFF
--- a/main.py
+++ b/main.py
@@ -1152,7 +1152,7 @@ Longest chain length: {config.high_score}
 {f"Last word by: <@{config.last_member_id}>" if config.last_member_id else ""}''',
             color=discord.Color.blurple()
         )
-        server_stats_embed.set_author(name=interaction.guild, icon_url=interaction.guild.icon)
+        server_stats_embed.set_author(name=interaction.guild, icon_url=interaction.guild.icon if interaction.guild.icon else None)
 
         await interaction.response.send_message(embed=server_stats_embed)
 
@@ -1166,6 +1166,14 @@ Longest chain length: {config.high_score}
 
         if member is None:
             member = interaction.user
+
+        def get_member_avatar() -> Optional[discord.Asset]:
+            if member.avatar:
+                return member.avatar
+            elif member.display_avatar:
+                return member.display_avatar
+            else:
+                return None
 
         async with Bot.SQL_ENGINE.begin() as connection:
             stmt = select(MemberModel).where(
@@ -1202,7 +1210,7 @@ Longest chain length: {config.high_score}
 **✅Correct:** {db_member.correct}
 **❌Wrong:** {db_member.wrong}
 **Accuracy:** {(db_member.correct / (db_member.correct + db_member.wrong)):.2%}'''
-            ).set_author(name=f"{member} | stats", icon_url=member.avatar)
+            ).set_author(name=f"{member} | stats", icon_url=get_member_avatar())
 
             await interaction.followup.send(embed=emb)
 

--- a/main.py
+++ b/main.py
@@ -893,7 +893,7 @@ async def leaderboard(interaction: discord.Interaction, type: Optional[app_comma
         title=f'Top 10 users by {board_metric}',
         color=discord.Color.blue(),
         description=''
-    ).set_author(name=interaction.guild.name, icon_url=interaction.guild.icon.url)
+    ).set_author(name=interaction.guild.name, icon_url=interaction.guild.icon.url if interaction.guild.icon else None)
 
     async with Bot.SQL_ENGINE.begin() as connection:
         async def fill_with_users(offset: int = 0, limit: int = 10) -> None:


### PR DESCRIPTION
Fixed the following error that is raised if a guild doesn't have an icon:

```
[2024-11-14 20:46:48,437] [ERROR] discord.app_commands.tree: Ignoring exception in command 'leaderboard'
Traceback (most recent call last):
  File "/home/container/.local/lib/python3.12/site-packages/discord/app_commands/commands.py", line 858, in _do_call
    return await self._callback(interaction, **params)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/container/main.py", line 896, in leaderboard
    ).set_author(name=interaction.guild.name, icon_url=interaction.guild.icon.url)
                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'url'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/container/.local/lib/python3.12/site-packages/discord/app_commands/tree.py", line 1310, in _call
    await command._invoke_with_namespace(interaction, namespace)
  File "/home/container/.local/lib/python3.12/site-packages/discord/app_commands/commands.py", line 883, in _invoke_with_namespace
    return await self._do_call(interaction, transformed_values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/container/.local/lib/python3.12/site-packages/discord/app_commands/commands.py", line 876, in _do_call
    raise CommandInvokeError(self, e) from e
discord.app_commands.errors.CommandInvokeError: Command 'leaderboard' raised an exception: AttributeError: 'NoneType' object has no attribute 'url'
```

Also fixed two other potential sources of `NoneType` errors arising from icons.