### PR TITLE
DB connection with lock

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import logging
 import os
 import time
 from collections import defaultdict, deque
-from typing import Optional, Sequence, AsyncIterator
+from typing import AsyncIterator, Optional, Sequence
 
 import discord
 from alembic import command as alembic_command

--- a/main.py
+++ b/main.py
@@ -427,8 +427,6 @@ The above entered word is **NOT** being taken into account.''')
             )
             await connection.execute(stmt)
 
-            # TODO this is an issue here - we are inside the context manager, but will be creating additional ones
-
             current_count = self.server_configs[server_id].current_count
 
             if current_count > 0 and current_count % 100 == 0:

--- a/model.py
+++ b/model.py
@@ -1,8 +1,8 @@
-from typing import Optional
+from typing import Callable, Optional
 
 from pydantic import BaseModel
 from sqlalchemy import Boolean, Float, Integer, String, update
-from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -124,11 +124,11 @@ class ServerConfig(BaseModel):
         ).where(ServerConfigModel.server_id == self.server_id)
         return stmt
 
-    async def sync_to_db(self, async_engine: AsyncEngine):
+    async def sync_to_db(self, async_engine_generator: Callable[[bool], AsyncConnection]):
         """
         Synchronizes itself with the DB.
         """
-        async with async_engine.begin() as connection:
+        async with async_engine_generator(True) as connection:
             stmt = self.__update_statement()
             await connection.execute(stmt)
             await connection.commit()

--- a/model.py
+++ b/model.py
@@ -1,3 +1,4 @@
+import contextlib
 from typing import Callable, Optional
 
 from pydantic import BaseModel
@@ -124,7 +125,7 @@ class ServerConfig(BaseModel):
         ).where(ServerConfigModel.server_id == self.server_id)
         return stmt
 
-    async def sync_to_db(self, async_engine_generator: Callable[[bool], AsyncConnection]):
+    async def sync_to_db(self, async_engine_generator: Callable[[bool], contextlib.AbstractAsyncContextManager[AsyncConnection]]):
         """
         Synchronizes itself with the DB.
         """


### PR DESCRIPTION
Creating a db connection can now lock it to force other requests to wait for its release. Read-only statements can also request a connection without a lock, because it should technically work.

We can also set the `__main__` logger to level `DEBUG` to log the time a request waited for a connection.

To make all of this possible, each interaction will use just a single connection. An interaction is a message processed by the bot as well as an interaction by the definition of discord itself, meaning slash commands.