### PR TITLE
Dynamic control over four main loggers via slash commands

### DIFF
--- a/cogs/manager_cmds.py
+++ b/cogs/manager_cmds.py
@@ -57,12 +57,12 @@ class ManagerCommandsCog(Cog, name=COG_NAME_MANAGER_CMDS):
         # ------------------------------------------------------------------------------------------------------------
 
         @app_commands.command(name='reliable_role',
-                              description='Sets the role to be used when a user attains a score of 100')
-        @app_commands.describe(role='The role to be used when a user attains a score of 100')
+                              description='Sets the role that a user gets upon reaching'
+                                          ' a karma of 50 and accuracy > 99%')
+        @app_commands.describe(role='The role to be used')
         @app_commands.default_permissions(manage_guild=True)
         async def set_reliable_role(self, interaction: Interaction, role: Role):
-            
-            """Command to set the role to be used when a user gets 100 of score"""
+            """Command to set the role to be used when a user attains 50 karma and accuracy > 99%"""
 
             await interaction.response.defer()
 
@@ -97,17 +97,19 @@ class ManagerCommandsCog(Cog, name=COG_NAME_MANAGER_CMDS):
 
         # ---------------------------------------------------------------------------------------------------------
 
-        @app_commands.command(name='channel', description='Sets the channel to count in')
-        @app_commands.describe(channel='The channel to count in')
+        @app_commands.command(name='channel', description='Sets the game channel')
+        @app_commands.describe(channel='The channel where the game will be played')
         async def set_channel(self, interaction: Interaction, channel: TextChannel):
-            """Command to set the channel to count in"""
+            """Command to set the play channel"""
 
             await interaction.response.defer()
 
             self.cog.bot.server_configs[interaction.guild.id].channel_id = channel.id
             await self.cog.bot.server_configs[interaction.guild.id].sync_to_db(self.cog.bot)
 
-            await interaction.followup.send(f'Word chain channel was set to {channel.mention}')
+            emb: Embed = Embed(title='Success', colour=Colour.green(),
+                               description=f'''Word chain channel was set to {channel.mention}.''')
+            await interaction.followup.send(embed=emb)
 
         # ---------------------------------------------------------------------------------------------------------
 
@@ -115,7 +117,7 @@ class ManagerCommandsCog(Cog, name=COG_NAME_MANAGER_CMDS):
                               description='Sets the role to be used when a user puts a wrong word')
         @app_commands.describe(role='The role to be used when a user puts a wrong word')
         async def set_failed_role(self, interaction: Interaction, role: Role):
-            """Command to set the role to be used when a user fails to count"""
+            """Command to set the role to be used when a user fails"""
 
             await interaction.response.defer()
 

--- a/cogs/manager_cmds.py
+++ b/cogs/manager_cmds.py
@@ -10,14 +10,14 @@ from discord.app_commands import Group
 from discord.ext.commands import Cog
 from sqlalchemy import CursorResult, delete, insert, select
 
-from consts import COG_NAME_MANAGER_CMDS, POSSIBLE_CHARACTERS
+from consts import COG_NAME_MANAGER_CMDS, POSSIBLE_CHARACTERS, LOGGER_NAME_MANAGER_COG
 from model import BlacklistModel, WhitelistModel
 
 if TYPE_CHECKING:
     from main import WordChainBot
 
 logging.basicConfig(level=logging.INFO, format='[%(asctime)s] [%(levelname)s] %(name)s: %(message)s')
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(LOGGER_NAME_MANAGER_COG)
 
 
 class ManagerCommandsCog(Cog, name=COG_NAME_MANAGER_CMDS):

--- a/cogs/user_cmds.py
+++ b/cogs/user_cmds.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from main import WordChainBot
 
 logging.basicConfig(level=logging.INFO, format='[%(asctime)s] [%(levelname)s] %(name)s: %(message)s')
-logger: logging.Logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(LOGGER_NAME_USER_COG)
 
 load_dotenv()
 ADMIN_GUILD_ID: int = int(os.environ['ADMIN_GUILD_ID'])

--- a/cogs/user_cmds.py
+++ b/cogs/user_cmds.py
@@ -61,10 +61,11 @@ class UserCommandsCog(Cog, name=COG_NAME_USER_CMDS):
 
         emb = Embed(title='Slash Commands', color=Colour.blue(),
                     description='''
-`/list_commands` - Lists all the slash commands.
-`/stats` - Shows the stats of a specific user/the current server
+`/stats user` - Shows the stats of a specific user.
+`/stats server` - Shows the stats of the current server.
 `/check_word` - Check if a word exists/check the spelling.
-`/leaderboard` - Shows the leaderboard of the server.''')
+`/leaderboard` - Shows the leaderboard of the server.
+`/list_commands` - Lists all the slash commands.''')
 
         if interaction.user.guild_permissions.manage_guild:
             emb.description += '''\n
@@ -84,9 +85,17 @@ class UserCommandsCog(Cog, name=COG_NAME_USER_CMDS):
         if interaction.user.guild_permissions.administrator and interaction.guild.id == ADMIN_GUILD_ID:
             emb.description += '''\n
 **Restricted commands — Bot Admins only**
+`/reload` - Reload a specific Cog (or all Cogs).
 `/purge_data server` - Remove all data associated with a server.
 `/purge_data user` - Remove all data associated with a user.
-`/reload` - Reload a specific Cog (or all Cogs).'''
+`/logging status` - Shows the status of the loggers.
+`/logging enable_all` - Enables the loggers.
+`/logging disable_all` - Disables the loggers.
+`/logging enable_logger` - Enables a specific logger.
+`/logging disable_logger` - Disables a specific logger.
+`/logging set_level` - Sets the log level of a specific logger/all loggers.
+`/logging test` - Tests a specific logger.
+'''
 
         await interaction.followup.send(embed=emb)
 

--- a/consts.py
+++ b/consts.py
@@ -6,11 +6,24 @@ If the input has any character(s) other than these, it will be ignored by the bo
 """
 POSSIBLE_CHARACTERS: str = string.ascii_lowercase + "-"
 
+"""
+Names of individual cogs
+"""
 COG_NAME_ADMIN_CMDS: str = "admin_cmds"
 COG_NAME_MANAGER_CMDS: str = "manager_cmds"
 COG_NAME_USER_CMDS: str = "user_cmds"
 
+"""
+List of all cogs.
+"""
 COGS_LIST: list[str] = [COG_NAME_ADMIN_CMDS, COG_NAME_MANAGER_CMDS,  COG_NAME_USER_CMDS]
+
+LOGGER_NAME_MAIN: str = "__main__"
+LOGGER_NAME_ADMIN_COG: str = f"__{COG_NAME_ADMIN_CMDS}__"
+LOGGER_NAME_MANAGER_COG: str = f"__{COG_NAME_MANAGER_CMDS}__"
+LOGGER_NAME_USER_COG: str = f"__{COG_NAME_USER_CMDS}__"
+
+LOGGERS_LIST: list[str] = [LOGGER_NAME_MAIN, LOGGER_NAME_ADMIN_COG, LOGGER_NAME_MANAGER_COG, LOGGER_NAME_USER_COG]
 
 """
 This dictionary maps each character to its frequency as the first letter in an english word. It is calculated by

--- a/consts.py
+++ b/consts.py
@@ -1,37 +1,29 @@
 import string
 
+POSSIBLE_CHARACTERS: str = string.ascii_lowercase + "-"
 """
 The allowed characters in the input.
 If the input has any character(s) other than these, it will be ignored by the bot.
 """
-POSSIBLE_CHARACTERS: str = string.ascii_lowercase + "-"
 
-"""
-Names of individual cogs
-"""
+# Names of individual cogs
 COG_NAME_ADMIN_CMDS: str = "admin_cmds"
 COG_NAME_MANAGER_CMDS: str = "manager_cmds"
 COG_NAME_USER_CMDS: str = "user_cmds"
 
-"""
-List of all cogs.
-"""
 COGS_LIST: list[str] = [COG_NAME_ADMIN_CMDS, COG_NAME_MANAGER_CMDS,  COG_NAME_USER_CMDS]
+"""List of all cogs."""
 
+# Names of individual loggers
 LOGGER_NAME_MAIN: str = "__main__"
 LOGGER_NAME_ADMIN_COG: str = f"__{COG_NAME_ADMIN_CMDS}__"
 LOGGER_NAME_MANAGER_COG: str = f"__{COG_NAME_MANAGER_CMDS}__"
 LOGGER_NAME_USER_COG: str = f"__{COG_NAME_USER_CMDS}__"
 
 LOGGERS_LIST: list[str] = [LOGGER_NAME_MAIN, LOGGER_NAME_ADMIN_COG, LOGGER_NAME_MANAGER_COG, LOGGER_NAME_USER_COG]
+"""List of all loggers."""
 
-"""
-This dictionary maps each character to its frequency as the first letter in an english word. It is calculated by
-multiplying the frequency with the total character count of 26. This results in scores around 1, with scores below 1
-meaning that this character occurs less than average as the first character, and scores above 1 meaning that this
-character occurs more than average as the first character.
-"""
-FIRST_CHAR_SCORE = {
+FIRST_CHAR_SCORE: dict[str, float] = {
     "a": 1.7855527485443319,
     "b": 1.293519406654868,
     "c": 2.25552748544332,
@@ -59,22 +51,25 @@ FIRST_CHAR_SCORE = {
     "y": 0.08029613217870604,
     "z": 0.09743721376366166
 }
+"""
+This dictionary maps each character to its frequency as the first letter in an english word. It is calculated by
+multiplying the frequency with the total character count of 26. This results in scores around 1, with scores below 1
+meaning that this character occurs less than average as the first character, and scores above 1 meaning that this
+character occurs more than average as the first character.
+"""
 
+HISTORY_LENGTH: int = 5
 """Amount of words kept in history per user"""
-HISTORY_LENGTH = 5
 
+MISTAKE_PENALTY: int = 5
 """Amount of karma subtracted for a mistake"""
-MISTAKE_PENALTY = 5
 
+RELIABLE_ROLE_KARMA_THRESHOLD: int = 50
 """Minimum karma needed for the reliable role"""
-RELIABLE_ROLE_KARMA_THRESHOLD = 50
 
+RELIABLE_ROLE_ACCURACY_THRESHOLD: float = .99
 """Minimum accuracy needed for the reliable role"""
-RELIABLE_ROLE_ACCURACY_THRESHOLD = .99
 
-"""
-A dictionary mapping the words to the corresponding special emojis.
-"""
 SPECIAL_REACTION_EMOJIS: dict[str, str] = {
     'afghanistan': '🇦🇫',
     'albania': '🇦🇱',
@@ -291,10 +286,10 @@ SPECIAL_REACTION_EMOJIS: dict[str, str] = {
     'russia': '🇷🇺',
     'indently': '<:python:1041232509628850247>'
 }
+"""
+A dictionary mapping the words to the corresponding special emojis.
+"""
 
-"""
-A list of 2-letter words that are not legal words.
-"""
 GLOBAL_BLACKLIST_2_LETTER_WORDS: set[str] = {
     'aa',
     'ab',
@@ -945,11 +940,10 @@ GLOBAL_BLACKLIST_2_LETTER_WORDS: set[str] = {
     'zy',
     'zz'
 }
+"""
+A list of 2-letter words that are not legal words.
+"""
 
-"""
-A global whitelist containing all LEGAL three letter words.
-NOTE: This is a WHITElist, i.e. an inverted blacklist.
-"""
 GLOBAL_WHITELIST_3_LETTER_WORDS: set[str] = {
     'eve',
     'ewe',
@@ -1306,10 +1300,11 @@ GLOBAL_WHITELIST_3_LETTER_WORDS: set[str] = {
     'sol',
     'yen'
 }
+"""
+A global whitelist containing all LEGAL three letter words.
+NOTE: This is a WHITElist, i.e. an inverted blacklist.
+"""
 
-"""
-A list of N-letter words that are not legal words (N > 3).
-"""
 GLOBAL_BLACKLIST_N_LETTER_WORDS: set[str] = {
     'aaaa',
     'bbbb',
@@ -1332,3 +1327,7 @@ GLOBAL_BLACKLIST_N_LETTER_WORDS: set[str] = {
     'mmmmmm',
     'pppppp'
 }
+"""
+A list of N-letter words that are not legal words (N > 3).
+"""
+

--- a/karma_calcs.py
+++ b/karma_calcs.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-import logging
 import math
 from collections import deque
 
 from consts import FIRST_CHAR_SCORE
-
-logging.basicConfig(level=logging.INFO, format='[%(asctime)s] [%(levelname)s] %(name)s: %(message)s')
-logger: logging.Logger = logging.getLogger(__name__)
 
 
 def calculate_decay(n: float, drop_rate: float = .33) -> float:

--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ ADMIN_GUILD_ID = int(os.environ['ADMIN_GUILD_ID'])
 
 # load logging config from alembic file because it would be loaded anyway when using alembic
 fileConfig(fname='config.ini')
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(LOGGER_NAME_MAIN)
 
 
 class WordChainBot(AutoShardedBot):


### PR DESCRIPTION
Four loggers can now be controlled via slash commands while the bot is running: the one for `main.py` and the ones for the three cogs containing the command groups.

Added functionality:

- `/logging status` - Shows the status of all the loggers/specific logger.
- `/logging enable_all` - Enables the loggers (with option to reset level to `INFO`; default: `True`)
- `/logging disable_all` - Disables the loggers.
- `/logging enable_logger` - Enables a specific logger (with option to reset level to `INFO`; default: `True`)
- `/logging disable_logger` - Disables a specific logger.
- `/logging set_level` - Sets the log level of a specific logger/all loggers.
- `/logging test` - Tests a specific logger.