### PR TITLE
Improved check for valid words

### DIFF
--- a/cogs/manager_cmds.py
+++ b/cogs/manager_cmds.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING
 
 import discord
@@ -10,7 +11,7 @@ from discord.app_commands import Group
 from discord.ext.commands import Cog
 from sqlalchemy import CursorResult, delete, insert, select
 
-from consts import COG_NAME_MANAGER_CMDS, FIRST_TOKEN_SCORES, LOGGER_NAME_MANAGER_COG, POSSIBLE_CHARACTERS, GameMode
+from consts import ALLOWED_WORDS_PATTERN, COG_NAME_MANAGER_CMDS, FIRST_TOKEN_SCORES, LOGGER_NAME_MANAGER_COG, GameMode
 from model import BlacklistModel, WhitelistModel
 
 if TYPE_CHECKING:
@@ -33,7 +34,7 @@ class ManagerCommandsCog(Cog, name=COG_NAME_MANAGER_CMDS):
 
     @staticmethod
     def is_generally_illegal_word(word: str):
-        return (not all(c in POSSIBLE_CHARACTERS for c in word.lower()) or
+        return (not re.search(ALLOWED_WORDS_PATTERN, word.lower()) or
                 any(word[:game_mode.value] not in FIRST_TOKEN_SCORES[game_mode] or
                     word[-game_mode.value:] not in FIRST_TOKEN_SCORES[game_mode]
                     for game_mode in GameMode)

--- a/cogs/user_cmds.py
+++ b/cogs/user_cmds.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import concurrent.futures
 import logging
 import os
+import re
 from collections import defaultdict
 from typing import TYPE_CHECKING, Optional, Sequence
 
@@ -73,7 +74,7 @@ class UserCommandsCog(Cog, name=COG_NAME_USER_CMDS):
 
         emb = Embed(color=Colour.blurple())
 
-        if not all(c in POSSIBLE_CHARACTERS for c in word.lower()):
+        if not re.search(ALLOWED_WORDS_PATTERN, word.lower()):
             emb.description = f'❌ **{word}** is **not** a legal word.'
             await interaction.followup.send(embed=emb)
             return

--- a/consts.py
+++ b/consts.py
@@ -9,11 +9,10 @@ class GameMode(Enum):
     NORMAL = 1
     HARD = 2
 
-
-POSSIBLE_CHARACTERS: str = string.ascii_lowercase + "-"
+ALLOWED_WORDS_PATTERN: str = r'^[a-z]+([-][a-z]+)*$'
 """
-The allowed characters in the input.
-If the input has any character(s) other than these, it will be ignored by the bot.
+Regex pattern for allowed words. A valid word has only lowercase ASCII letters and may have hyphens anywhere in the
+middle of the word, but not in the start or end of the word.
 """
 
 # Names of individual cogs

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import inspect
 import logging
 import os
 import random
+import re
 import time
 from collections import defaultdict, deque
 from logging.config import fileConfig
@@ -279,7 +280,7 @@ class WordChainBot(AutoShardedBot):
         server_id = message.guild.id
         word: str = message.content.lower()
 
-        if not all(c in POSSIBLE_CHARACTERS for c in word):
+        if not re.search(ALLOWED_WORDS_PATTERN, word):
             return
         if len(word) == 0:
             return
@@ -683,7 +684,7 @@ The above entered word is **NOT** being taken into account.''')
             return
         if not message.reactions:
             return
-        if not all(c in POSSIBLE_CHARACTERS for c in message.content.lower()):
+        if not re.search(ALLOWED_WORDS_PATTERN, message.content.lower()):
             return
 
         if message.channel.id == self.server_configs[message.guild.id].game_state[GameMode.NORMAL].channel_id:
@@ -716,7 +717,7 @@ The above entered word is **NOT** being taken into account.''')
             return
         if not before.reactions:
             return
-        if not all(c in POSSIBLE_CHARACTERS for c in before.content.lower()):
+        if not re.search(ALLOWED_WORDS_PATTERN, before.content.lower()):
             return
         if before.content.lower() == after.content.lower():
             return


### PR DESCRIPTION
Uses now regex to validate that words have only lowercase ascii letters, and may have hyphens somewhere in the middle, but not in the start or end of the word.